### PR TITLE
Renaming Characterizer to Characterizers::Fits

### DIFF
--- a/lib/hydra-file_characterization.rb
+++ b/lib/hydra-file_characterization.rb
@@ -1,5 +1,6 @@
 require "hydra-file_characterization/version"
-require "hydra-file_characterization/characterizer"
+require "hydra-file_characterization/characterizers/fits"
+require "hydra-file_characterization/to_temp_file"
 require "active_support/configurable"
 
 module Hydra

--- a/lib/hydra-file_characterization/characterizers/fits.rb
+++ b/lib/hydra-file_characterization/characterizers/fits.rb
@@ -1,12 +1,9 @@
 require 'open3'
-
-module Hydra::FileCharacterization
-
-  class Characterizer
+module Hydra::FileCharacterization::Characterizers
+  class FileNotFoundError < RuntimeError
+  end
+  class Fits
     include Open3
-
-    class FileNotFoundError < RuntimeError
-    end
 
     attr_reader :filename, :fits_path
     def initialize(filename, fits_path)
@@ -16,7 +13,7 @@ module Hydra::FileCharacterization
 
     def call
       unless File.exists?(filename)
-        raise FileNotFoundError.new("File: #{filename} does not exist.")
+        raise Hydra::FileCharacterization::Characterizers::FileNotFoundError.new("File: #{filename} does not exist.")
       end
       command = "#{fits_path} -i \"#{filename}\""
       stdin, stdout, stderr, wait_thr = popen3(command)

--- a/spec/lib/hydra-file_characterization/characterizers/fits_spec.rb
+++ b/spec/lib/hydra-file_characterization/characterizers/fits_spec.rb
@@ -1,14 +1,16 @@
 require 'spec_helper'
-require 'hydra-file_characterization'
+require 'hydra-file_characterization/characterizers/fits'
 
-describe Hydra::FileCharacterization do
-  describe 'Characterizer' do
-    def fixture_file(filename)
-      File.expand_path(File.join('../../../fixtures', filename), __FILE__)
-    end
+module Hydra::FileCharacterization::Characterizers
 
+  describe Fits do
+
+    subject { Fits.new(filename, fits_path) }
     let(:fits_path) { `which fits || which fits.sh`.strip }
-    subject { Hydra::FileCharacterization::Characterizer.new(filename, fits_path) }
+
+    def fixture_file(filename)
+      File.expand_path(File.join('../../../../fixtures', filename), __FILE__)
+    end
 
     describe 'validfile' do
       let(:filename) { fixture_file('brendan_behan.jpeg') }
@@ -20,7 +22,7 @@ describe Hydra::FileCharacterization do
     describe 'invalidFile' do
       let(:filename) { fixture_file('nofile.pdf') }
       it "should raise an error if the path does not contain the file" do
-        expect {subject.call}.to raise_error(Hydra::FileCharacterization::Characterizer::FileNotFoundError)
+        expect {subject.call}.to raise_error(FileNotFoundError)
       end
     end
 
@@ -37,4 +39,5 @@ describe Hydra::FileCharacterization do
     end
 
   end
+
 end


### PR DESCRIPTION
Given that we are going to allow for multiple characterizations, we
should account for that behavior by namespacing the available
characterization tools.
