### PR TITLE
Fall back to convention for toolname

### DIFF
--- a/lib/hydra/file_characterization/characterizer.rb
+++ b/lib/hydra/file_characterization/characterizer.rb
@@ -27,10 +27,14 @@ module Hydra::FileCharacterization
     end
 
     def tool_path
-      @tool_path || self.class.tool_path || (raise Hydra::FileCharacterization::UnspecifiedToolPathError.new(self.class))
+      @tool_path || self.class.tool_path || convention_based_tool_name
     end
 
     protected
+
+    def convention_based_tool_name
+      self.class.name.split("::").last.downcase
+    end
 
     def internal_call
       stdin, stdout, stderr, wait_thr = popen3(command)

--- a/lib/hydra/file_characterization/exceptions.rb
+++ b/lib/hydra/file_characterization/exceptions.rb
@@ -1,11 +1,5 @@
 module Hydra::FileCharacterization
 
-  class UnspecifiedToolPathError < RuntimeError
-    def initialize(tool_class)
-      super("Unspecified tool path for #{tool_class}")
-    end
-  end
-
   class FileNotFoundError < RuntimeError
   end
 

--- a/spec/lib/hydra/file_characterization/characterizer_spec.rb
+++ b/spec/lib/hydra/file_characterization/characterizer_spec.rb
@@ -45,11 +45,7 @@ module Hydra::FileCharacterization
       end
 
       context 'without a specified tool_path' do
-        it 'should raise Hydra::FileCharacterization::UnspecifiedToolPathError' do
-          expect {
-            subject.tool_path
-          }.to raise_error(Hydra::FileCharacterization::UnspecifiedToolPathError)
-        end
+        its(:tool_path) { should eq 'characterizer' }
       end
     end
   end

--- a/spec/lib/hydra/file_characterization_spec.rb
+++ b/spec/lib/hydra/file_characterization_spec.rb
@@ -71,10 +71,9 @@ module Hydra
         Hydra::FileCharacterization.configure do |config|
           config.tool_path(:fits, nil)
         end
+        response = Hydra::FileCharacterization.characterize(content, filename, :fits)
+        expect(response).to match(/#{'<identity format="Plain text" mimetype="text/plain"'}/)
 
-        expect {
-          Hydra::FileCharacterization.characterize(content, filename, :fits)
-        }.to raise_error(Hydra::FileCharacterization::UnspecifiedToolPathError)
       end
     end
 


### PR DESCRIPTION
Instead of raising an error if the tool_path is not configured,
fall back to a derived tool_path which would lean on the User's
PATH.

Closes #12
