### PR TITLE
Allow characterize to use an existing file, not just a string.

### DIFF
--- a/spec/lib/hydra/file_characterization_spec.rb
+++ b/spec/lib/hydra/file_characterization_spec.rb
@@ -7,56 +7,67 @@ module Hydra
   describe FileCharacterization do
 
     describe '.characterize' do
-      let(:content) { "class Test; end\n" }
-      let(:filename) { 'test.rb' }
-      subject { Hydra::FileCharacterization.characterize(content, filename, tool_names) }
+      describe "for content in memory" do
+        let(:content) { "class Test; end\n" }
+        let(:filename) { 'test.rb' }
+        subject { Hydra::FileCharacterization.characterize(content, filename, tool_names) }
 
-      describe 'for fits' do
-        let(:tool_names) { [:fits] }
-        it { should match(/#{'<identity format="Plain text" mimetype="text/plain"'}/) }
+        describe 'for fits' do
+          let(:tool_names) { [:fits] }
+          it { should match(/#{'<identity format="Plain text" mimetype="text/plain"'}/) }
+        end
+
+        describe 'with configured path' do
+          it {
+            response = Hydra::FileCharacterization.characterize(content, filename, :fits) do |config|
+              config[:fits] = `which fits || which fits.sh`.strip
+            end
+            expect(response).to match(/#{'<identity format="Plain text" mimetype="text/plain"'}/)
+          }
+        end
+
+        describe 'with multiple runs' do
+          it {
+            response_1, response_2, response_3 = Hydra::FileCharacterization.characterize(content, filename, :fits, :fits)
+            expect(response_1).to match(/#{'<identity format="Plain text" mimetype="text/plain"'}/)
+            expect(response_2).to match(/#{'<identity format="Plain text" mimetype="text/plain"'}/)
+            expect(response_3).to be_nil
+          }
+        end
+
+        describe 'for a bogus tool' do
+          let(:tool_names) { [:cookie_monster] }
+          it {
+            expect {
+              subject
+            }.to raise_error(Hydra::FileCharacterization::ToolNotFoundError)
+          }
+        end
+
+        describe 'for a mix of bogus and valid tools' do
+          let(:tool_names) { [:fits, :cookie_monster] }
+          it {
+            expect {
+              subject
+            }.to raise_error(Hydra::FileCharacterization::ToolNotFoundError)
+          }
+        end
+
+        describe 'for no tools' do
+          let(:tool_names) { nil }
+          it { should eq [] }
+        end
       end
 
-      describe 'with configured path' do
-        it {
-          response = Hydra::FileCharacterization.characterize(content, filename, :fits) do |config|
-            config[:fits] = `which fits || which fits.sh`.strip
-          end
-          expect(response).to match(/#{'<identity format="Plain text" mimetype="text/plain"'}/)
-        }
-      end
+      describe "for a file on disk" do
+        let(:file) { File.open(fixture_file('brendan_behan.jpeg')) }
+        subject { Hydra::FileCharacterization.characterize(file, tool_names) }
 
-      describe 'with multiple runs' do
-        it {
-          response_1, response_2, response_3 = Hydra::FileCharacterization.characterize(content, filename, :fits, :fits)
-          expect(response_1).to match(/#{'<identity format="Plain text" mimetype="text/plain"'}/)
-          expect(response_2).to match(/#{'<identity format="Plain text" mimetype="text/plain"'}/)
-          expect(response_3).to be_nil
-        }
+        describe 'for fits' do
+          let(:tool_names) { [:fits] }
+          it { should match(/#{'<identity format="JPEG File Interchange Format" mimetype="image/jpeg"'}/) }
+        end
       end
-
-      describe 'for a bogus tool' do
-        let(:tool_names) { [:cookie_monster] }
-        it {
-          expect {
-            subject
-          }.to raise_error(Hydra::FileCharacterization::ToolNotFoundError)
-        }
-      end
-
-      describe 'for a mix of bogus and valid tools' do
-        let(:tool_names) { [:fits, :cookie_monster] }
-        it {
-          expect {
-            subject
-          }.to raise_error(Hydra::FileCharacterization::ToolNotFoundError)
-        }
-      end
-
-      describe 'for no tools' do
-        let(:tool_names) { nil }
-        it { should eq [] }
-      end
-
     end
     describe '.configure' do
       let(:content) { "class Test; end\n" }


### PR DESCRIPTION
This is useful if you have an external datastream, and it's too big to
load into memory.  Fixes #14
