### PR TITLE
Handle File and string filename passed to characterize.

### DIFF
--- a/lib/hydra/file_characterization.rb
+++ b/lib/hydra/file_characterization.rb
@@ -42,6 +42,9 @@ module Hydra
     # @example With an open file
     #   fits_xml, ffprobe_xml = Hydra::FileCharacterization.characterize(File.open('foo.mkv'), :fits, :ffprobe)
     #
+    # @example With an open file and a filename
+    #   fits_xml, ffprobe_xml = Hydra::FileCharacterization.characterize(File.open('foo.mkv'), 'my_movie.mkv', :fits, :ffprobe)
+    #
     # @param [String] content - The contents of the original file
     # @param [String] filename - The original file's filename; Some
     #   characterization tools take hints from the file names
@@ -82,7 +85,7 @@ module Hydra
       # @return [String, File], [String], [Array]
       def self.extract_arguments(args)
         content = args.shift
-        filename = if content.is_a? File
+        filename = if content.is_a?(File) && !args[0].is_a?(String)
           File.basename(content.path)
         else
            args.shift

--- a/spec/lib/hydra/file_characterization_spec.rb
+++ b/spec/lib/hydra/file_characterization_spec.rb
@@ -61,11 +61,22 @@ module Hydra
 
       describe "for a file on disk" do
         let(:file) { File.open(fixture_file('brendan_behan.jpeg')) }
-        subject { Hydra::FileCharacterization.characterize(file, tool_names) }
+        describe "without path specified" do
+          subject { Hydra::FileCharacterization.characterize(file, tool_names) }
 
-        describe 'for fits' do
-          let(:tool_names) { [:fits] }
-          it { should match(/#{'<identity format="JPEG File Interchange Format" mimetype="image/jpeg"'}/) }
+          describe 'for fits' do
+            let(:tool_names) { [:fits] }
+            it { should match(/#{'<identity format="JPEG File Interchange Format" mimetype="image/jpeg"'}/) }
+          end
+        end
+        describe "with path specified" do
+          let(:file) { File.open(fixture_file('brendan_behan.jpeg')) }
+          subject { Hydra::FileCharacterization.characterize(file, 'Brendan.jpg', tool_names) }
+
+          describe 'for fits' do
+            let(:tool_names) { [:fits] }
+            it { should match(/#{'<identity format="JPEG File Interchange Format" mimetype="image/jpeg"'}/) }
+          end
         end
       end
     end


### PR DESCRIPTION
This happens if you characterize an object before saving because
Rubydora doesn't read the file until save.
