### PR TITLE
Allow usage of FITS Servlet

### DIFF
--- a/lib/hydra/file_characterization/characterizers.rb
+++ b/lib/hydra/file_characterization/characterizers.rb
@@ -29,3 +29,4 @@ end
 
 require 'hydra/file_characterization/characterizers/fits'
 require 'hydra/file_characterization/characterizers/ffprobe'
+require 'hydra/file_characterization/characterizers/fits_servlet'

--- a/lib/hydra/file_characterization/characterizers/fits_servlet.rb
+++ b/lib/hydra/file_characterization/characterizers/fits_servlet.rb
@@ -1,0 +1,23 @@
+require 'hydra/file_characterization/exceptions'
+require 'hydra/file_characterization/characterizer'
+require 'logger'
+module Hydra::FileCharacterization::Characterizers
+  class FitsServlet < Hydra::FileCharacterization::Characterizer
+
+    protected
+
+      def command
+        "curl -k -F datafile=@#{filename} #{ENV['FITS_SERVLET_URL']}/examine"
+      end
+
+      # Remove any non-XML output that precedes the <?xml> tag
+      # See: https://github.com/harvard-lts/fits/issues/20
+      #      https://github.com/harvard-lts/fits/issues/40
+      #      https://github.com/harvard-lts/fits/issues/46
+      def post_process(raw_output)
+        md = /\A(.*)(<\?xml.*)\Z/m.match(raw_output)
+        logger.warn "FITS produced non-xml output: \"#{md[1].chomp}\"" unless md[1].empty?
+        md[2]
+      end
+  end
+end

--- a/spec/lib/hydra/file_characterization/characterizers/fit_servlet_spec.rb
+++ b/spec/lib/hydra/file_characterization/characterizers/fit_servlet_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'hydra/file_characterization/characterizers/fits_servlet'
+
+module Hydra::FileCharacterization::Characterizers
+  describe FitsServlet do
+    let(:fits) { Fits.new(filename) }
+
+    describe "#call", unless: ENV['TRAVIS'] do
+      subject { fits.call }
+
+      context 'validfile' do
+        let(:filename) { fixture_file('brendan_behan.jpeg') }
+        it { is_expected.to include(%(<identity format="JPEG File Interchange Format" mimetype="image/jpeg")) }
+      end
+
+      context 'invalidFile' do
+        let(:filename) { fixture_file('nofile.pdf') }
+        it "raises an error" do
+          expect { subject }.to raise_error(Hydra::FileCharacterization::FileNotFoundError)
+        end
+      end
+
+      context 'corruptFile' do
+        let(:filename) { fixture_file('brendan_broken.dxxd') }
+        it { is_expected.to include(%(<identity format="Unknown Binary" mimetype="application/octet-stream")) }
+      end
+
+      context 'zip file should be characterized not its contents' do
+        let(:filename) { fixture_file('archive.zip') }
+        it { is_expected.to include(%(<identity format="ZIP Format" mimetype="application/zip"))}
+      end
+    end
+
+    context 'when JHOVE adds non-xml' do
+      # https://github.com/harvard-lts/fits/issues/20
+      subject { fits.call }
+
+      before do
+        expect(fits.logger).to receive(:warn)
+        allow(fits).to receive(:internal_call).and_return(
+          'READBOX seen=true
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.8.2" timestamp="15/09/14 10:00 AM">
+<identification/></fits>')
+      end
+
+      let(:filename) { fixture_file('brendan_behan.jpeg') }
+      it { is_expected.not_to include('READBOX') }
+    end
+
+    context "when FITS itself adds non-xml" do
+      # https://github.com/harvard-lts/fits/issues/46
+      subject { fits.call }
+
+      before do
+        expect(fits.logger).to receive(:warn)
+        allow(fits).to receive(:internal_call).and_return(
+          '2015-10-15 17:14:25,761 ERROR [main] ToolBelt:79 - Thread 1 error initializing edu.harvard.hul.ois.fits.tools.droid.Droid: edu.harvard.hul.ois.fits.exceptions.FitsToolException  Message: DROID cannot run under Java 8
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.8.2" timestamp="15/09/14 10:00 AM">
+<identification/></fits>')
+      end
+
+      let(:filename) { fixture_file('brendan_behan.jpeg') }
+      it { is_expected.not_to include('FitsToolException') }
+    end
+  end
+end


### PR DESCRIPTION
FITS servlet is a verison of FITS that runs on a web
server. It's much more efficient than running it via
the shell script, because it doesn't need to be reinitialized
each time it is called. That improves performance when
running running FITS on a large number of files.

This PR allows you to use that version of FITS by setting
the `FITS_SERVLET_URL` and using the `FitsServlet` Characterizer
class.